### PR TITLE
Fix topic wildcard validation edge case

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
 function validateTopic (topic, message) {
   const end = topic.length - 1
   const endMinus = end - 1
-  const slashInPreEnd = endMinus > 0 && topic.charCodeAt(endMinus) !== 47
+  const slashInPreEnd = endMinus >= 0 && topic.charCodeAt(endMinus) !== 47
   if (topic.length === 0) { // [MQTT-3.8.3-3]
     return new Error('impossible to ' + message + ' to an empty topic')
   }


### PR DESCRIPTION
## Summary
- fix validation logic when a wildcard `#` is used without a preceding `/` in subscribe/unsubscribe topics

## Testing
- `npm test` *(fails: standard not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e524a6d8832d9e1c060ab7571183